### PR TITLE
Add LIBS input property to GENERATE_ARDUINO_EXAMPLE

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -179,6 +179,7 @@
 #                          LIBRARY library_name
 #                          EXAMPLE example_name
 #                          [BOARD  board_id]
+#                          [LIBS  lib1 lib2 ... libN]
 #                          [PORT port]
 #                          [SERIAL serial command]
 #                          [PORGRAMMER programmer_id]
@@ -189,6 +190,7 @@
 #        LIBRARY      - Library name                           [REQUIRED]
 #        EXAMPLE      - Example name                           [REQUIRED]
 #        BOARD        - Board ID
+#        LIBS         - Libraries to link
 #        PORT         - Serial port [optional]
 #        SERIAL       - Serial command [optional]
 #        PROGRAMMER   - Programmer id (enables programmer support)
@@ -585,7 +587,7 @@ function(GENERATE_ARDUINO_EXAMPLE INPUT_NAME)
     parse_generator_arguments(${INPUT_NAME} INPUT
                               ""                                       # Options
                               "LIBRARY;EXAMPLE;BOARD;PORT;PROGRAMMER"  # One Value Keywords
-                              "SERIAL;AFLAGS"                          # Multi Value Keywords
+                              "SERIAL;AFLAGS;LIBS"                     # Multi Value Keywords
                               ${ARGN})
 
 


### PR DESCRIPTION
This allows users to add static libraries to fix linking errors with `generate_arduino_example` that can sometimes occur.

Some arduino examples with multiple dependencies give linking errors (undefined references) when built with the `generate_arduino_example` command. For example,

```
generate_arduino_example(cardinfo-ex 
      LIBRARY SD
      EXAMPLE CardInfo
      BOARD pro) 
```

Will fail to properly link with the SPI library. There is possibly a way to fix this under-the-hood with improved dependency discovery. I don't know where to start with this. As work-around that is perfectly consistent with the other arduino-cmake function, this change adds the **LIBS** input argument to `generate_arduino_example`. This works like the existing LIBS inputs on `generate_arduino_firmware` and `generate_arduino_library`

The user can now use `generate_arduino_library` to create a static library for SPI, and then build the example with

```
generate_arduino_example(cardinfo-ex 
      LIBRARY SD
      EXAMPLE CardInfo
      LIBS SPI #SPI target created with generate_arduino_library
      BOARD pro) 
```

The cmake source code for the `generate_arduino_example` already handled
this input since it contains `list(APPEND ALL_LIBS ${CORE_LIB} ${INPUT_LIBS})`, so no changes were necessary for the function itself.

Hopefully this is helpful.
