### PR TITLE
Include ASM files

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -1481,7 +1481,8 @@ function(find_sources VAR_NAME LIB_PATH RECURSE)
         ${LIB_PATH}/*.cxx
         ${LIB_PATH}/*.h
         ${LIB_PATH}/*.hh
-        ${LIB_PATH}/*.hxx)
+        ${LIB_PATH}/*.hxx
+        ${LIB_PATH}/*.S)
 
     if(RECURSE)
         file(GLOB_RECURSE LIB_FILES ${FILE_SEARCH_LIST})


### PR DESCRIPTION
Some core Arduino libraries involve assembly files (ex: wiring_pulse.S), which are not included and can lead to build errors when the functions contained in these libraries are needed.